### PR TITLE
feat: 完成 Repo Monitor MVP 落地与测试补强

### DIFF
--- a/internal/gitcli/repo_test.go
+++ b/internal/gitcli/repo_test.go
@@ -172,3 +172,28 @@ func TestClassifySync(t *testing.T) {
 		t.Fatalf("diverged failed")
 	}
 }
+
+func TestParseOwnerRepoFromRemote(t *testing.T) {
+	fx := fakeExec{out: map[string]string{
+		key("remote", "get-url", "origin"): "https://github.com/abc/def.git",
+	}}
+	cli := NewWithExecutor(fx)
+	o, r, err := cli.ParseOwnerRepoFromRemote(context.Background(), "/tmp/x")
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if o != "abc" || r != "def" {
+		t.Fatalf("owner/repo=%s/%s", o, r)
+	}
+}
+
+func TestListBranchesError(t *testing.T) {
+	fx := fakeExec{err: map[string]error{
+		key("for-each-ref", "--format=%(refname:short)|%(upstream:short)|%(HEAD)", "refs/heads"): errors.New("boom"),
+	}}
+	cli := NewWithExecutor(fx)
+	_, err := cli.ListBranches(context.Background(), "/tmp/x", false)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/internal/provider/github/client_test.go
+++ b/internal/provider/github/client_test.go
@@ -137,3 +137,39 @@ func TestResolveTokenEmptyWhenNoEnvAndGhFail(t *testing.T) {
 		t.Fatalf("token=%s", tok)
 	}
 }
+
+func TestListIssuesUsesCache(t *testing.T) {
+	c := &Client{
+		client:     gh.NewClient(nil),
+		auth:       true,
+		issueCache: cache.NewTTLCache[[]model.IssueItem](time.Minute),
+	}
+	now := time.Now()
+	c.issueCache.Set("o/r", []model.IssueItem{{Number: 9, Title: "cached"}}, now)
+
+	issues, err := c.ListIssues(context.Background(), "o", "r")
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 9 {
+		t.Fatalf("unexpected issues=%+v", issues)
+	}
+}
+
+func TestDiffUsesCache(t *testing.T) {
+	c := &Client{
+		client:    gh.NewClient(nil),
+		auth:      true,
+		diffCache: cache.NewTTLCache[string](time.Minute),
+	}
+	now := time.Now()
+	c.diffCache.Set("o/r/1", "cached-diff", now)
+
+	diff, err := c.PullRequestDiff(context.Background(), "o", "r", 1)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if diff != "cached-diff" {
+		t.Fatalf("diff=%s", diff)
+	}
+}

--- a/internal/tui/app_flow_test.go
+++ b/internal/tui/app_flow_test.go
@@ -124,3 +124,41 @@ func TestViewsNotEmpty(t *testing.T) {
 		t.Fatalf("diff empty")
 	}
 }
+
+func TestUpdateDetailPRAndIssueCursorMove(t *testing.T) {
+	a := newTestApp()
+	a.screen = screenDetail
+	a.prList = []model.PullRequestItem{{Number: 1}, {Number: 2}}
+	a.issues = []model.IssueItem{{Number: 1}, {Number: 2}}
+
+	a.detailTab = tabPR
+	_, _ = a.updateDetail(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if a.detailPRIdx != 1 {
+		t.Fatalf("pr idx=%d", a.detailPRIdx)
+	}
+
+	a.detailTab = tabIssue
+	_, _ = a.updateDetail(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if a.detailISIdx != 1 {
+		t.Fatalf("issue idx=%d", a.detailISIdx)
+	}
+}
+
+func TestUpdateDiffEscBackToDetail(t *testing.T) {
+	a := newTestApp()
+	a.screen = screenDiff
+	_, _ = a.updateDiff(tea.KeyMsg{Type: tea.KeyEsc})
+	if a.screen != screenDetail {
+		t.Fatalf("expected detail")
+	}
+}
+
+func TestJumpMatchNoMatchSafe(t *testing.T) {
+	a := newTestApp()
+	a.matches = nil
+	a.matchIdx = -1
+	a.jumpMatch(1)
+	if a.matchIdx != -1 {
+		t.Fatalf("matchIdx=%d", a.matchIdx)
+	}
+}


### PR DESCRIPTION
## 这次的更改
- 按需求文档完成 Repo Monitor MVP：实现 workspace 一级仓库扫描、本地 Git 状态采集（branch/upstream/ahead/behind/dirty/error）、首页与详情页 TUI 交互、PR Diff 只读查看。
- 增加 GitHub 只读能力：支持 `GITHUB_TOKEN` 与 `gh auth token` 自动获取，支持 PR 列表、Issues 列表（过滤 PR issue）、PR diff 拉取，并加入 60 秒缓存。
- 补强测试覆盖：新增并扩展 `gitcli`、`provider/github`、`tui` 的关键分支与缓存路径测试，提升低覆盖包的有效覆盖率。

## 涉及范围
- CLI 入口：`cmd/repo-monitor`
- 本地仓库与 Git 逻辑：`internal/workspace`、`internal/gitcli`
- 远端只读与缓存：`internal/provider/github`、`internal/cache`
- 界面与交互：`internal/tui`
- 共享模型与配置：`internal/model`、`internal/config`

## 有没有风险
- 当前 `internal/tui` 仍存在较多交互分支，虽然已补强测试，但覆盖率仍低于其他包，后续可继续拆分状态机纯函数进一步提升。
- GitHub 相关能力受外部网络和 token 状态影响，未认证时会按设计降级为只显示本地状态。

## 验证结果
- `go test ./... -cover -count=1` 通过
- `go build ./...` 通过