### PR TITLE
修复首页卡片多列错位并提升可读性

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -400,7 +400,18 @@ func (a *App) viewHome() string {
 			selected := (j == a.selectedIndex)
 			cards = append(cards, a.renderCard(repos[j], selected))
 		}
-		rows = append(rows, strings.Join(cards, strings.Repeat(" ", cardGap)))
+		if len(cards) == 1 {
+			rows = append(rows, cards[0])
+			continue
+		}
+		segments := make([]string, 0, len(cards)*2-1)
+		for idx, card := range cards {
+			if idx > 0 {
+				segments = append(segments, strings.Repeat(" ", cardGap))
+			}
+			segments = append(segments, card)
+		}
+		rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, segments...))
 	}
 
 	lines = append(lines, rows...)
@@ -409,13 +420,18 @@ func (a *App) viewHome() string {
 }
 
 func (a *App) renderCard(repo model.RepoStatus, selected bool) string {
-	borderColor := lipgloss.Color("240")
+	borderColor := lipgloss.AdaptiveColor{Light: "#8A8A8A", Dark: "#5F5F5F"}
+	cardBg := lipgloss.AdaptiveColor{Light: "#F6F4EE", Dark: "#232327"}
+	cardFg := lipgloss.AdaptiveColor{Light: "#2C3743", Dark: "#E5E7EB"}
 	if selected {
-		borderColor = lipgloss.Color("63")
+		borderColor = lipgloss.AdaptiveColor{Light: "#2B6FE8", Dark: "#6EA8FF"}
+		cardBg = lipgloss.AdaptiveColor{Light: "#EEF4FF", Dark: "#1D2636"}
 	}
 	s := lipgloss.NewStyle().
 		Width(a.cardWidth).
 		Padding(0, 1).
+		Foreground(cardFg).
+		Background(cardBg).
 		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor)
 

--- a/internal/tui/app_flow_test.go
+++ b/internal/tui/app_flow_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Fairfarren/peekgit/internal/config"
@@ -122,6 +123,27 @@ func TestViewsNotEmpty(t *testing.T) {
 	a.diffViewport.SetContent("diff")
 	if a.viewDiff() == "" {
 		t.Fatalf("diff empty")
+	}
+}
+
+func TestViewHomeMultiColumnCardsStayInSameRow(t *testing.T) {
+	a := newTestApp()
+	a.width = 120
+	a.recomputeGrid()
+
+	view := a.viewHome()
+	lines := strings.Split(view, "\n")
+
+	hasSameLine := false
+	for _, line := range lines {
+		if strings.Contains(line, "repo-a") && strings.Contains(line, "repo-b") {
+			hasSameLine = true
+			break
+		}
+	}
+
+	if !hasSameLine {
+		t.Fatalf("expected repo-a and repo-b to render in the same visual row, view:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## 这次的更改
- 问题是什么：首页在多列模式下使用字符串直接拼接多行卡片，导致第二列卡片内容错位，表现为右侧卡片看起来只剩边框线。
- 解决方案是什么：将多列卡片渲染改为 `lipgloss.JoinHorizontal(lipgloss.Top, ...)` 顶部对齐拼接，并保留固定卡片间距，避免多行内容被错误串接。
- 修复结论是什么：新增回归测试覆盖多列同排渲染场景，`go test ./...` 与 `go build ./...` 均通过。
- 额外优化：调整卡片边框、背景、前景与选中态配色，提升浅色/深色终端下的信息可读性和选中辨识度。

## 涉及范围
- `internal/tui/app.go`（首页卡片布局拼接逻辑、卡片颜色样式）
- `internal/tui/app_flow_test.go`（新增多列布局回归测试）

## 有没有风险
- 低风险：变更仅限 TUI 首页卡片渲染与相关测试，不涉及 Git/GitHub 数据获取流程。
- 已验证：全量测试与构建通过；主要风险在于不同终端主题下的视觉差异，已通过 AdaptiveColor 做兼容。