### PR TITLE
fix: 修复首页 PR 数量显示为 - 的问题

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -51,6 +51,8 @@ type remoteLoadedMsg struct {
 	issues    []model.IssueItem
 	branches  []model.BranchInfo
 	remoteErr string
+	prOpen    *int
+	issueOpen *int
 }
 
 type diffLoadedMsg struct {
@@ -157,6 +159,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.issues = m.issues
 		a.branches = m.branches
 		a.remoteErr = m.remoteErr
+		a.updateRepoOpenCounts(m.repoPath, m.prOpen, m.issueOpen)
 		return a, nil
 
 	case diffLoadedMsg:
@@ -550,7 +553,21 @@ func (a *App) refreshAllCmd() tea.Cmd {
 			sem <- struct{}{}
 			go func() {
 				defer func() { <-sem }()
-				ch <- a.git.RefreshRepo(ctx, r.Name, r.Path)
+				status := a.git.RefreshRepo(ctx, r.Name, r.Path)
+				if a.gh.Authenticated() && status.Error != model.RepoErrNoRemote && status.Error != model.RepoErrNotARepo {
+					owner, rname, err := a.git.ParseOwnerRepoFromRemote(ctx, r.Path)
+					if err == nil {
+						prs, errPR := a.gh.ListPRs(ctx, owner, rname)
+						issues, errIssue := a.gh.ListIssues(ctx, owner, rname)
+						if errPR == nil && errIssue == nil {
+							prValue := len(prs)
+							issueValue := len(issues)
+							status.PROpen = &prValue
+							status.IssueOpen = &issueValue
+						}
+					}
+				}
+				ch <- status
 			}()
 		}
 		for i := 0; i < cap(sem); i++ {
@@ -579,12 +596,19 @@ func (a *App) loadRemoteCmd(repo model.RepoStatus) tea.Cmd {
 		prs, errPR := a.gh.ListPRs(ctx, owner, rname)
 		issues, errIssue := a.gh.ListIssues(ctx, owner, rname)
 		remoteErr := ""
+		var prOpen *int
+		var issueOpen *int
 		if errPR == ghprovider.ErrUnauthenticated || errIssue == ghprovider.ErrUnauthenticated {
 			remoteErr = "unauth"
 			prs = []model.PullRequestItem{}
 			issues = []model.IssueItem{}
 		} else if errPR != nil || errIssue != nil {
 			remoteErr = "fetch"
+		} else {
+			prValue := len(prs)
+			issueValue := len(issues)
+			prOpen = &prValue
+			issueOpen = &issueValue
 		}
 		return remoteLoadedMsg{
 			repoPath:  repo.Path,
@@ -592,7 +616,20 @@ func (a *App) loadRemoteCmd(repo model.RepoStatus) tea.Cmd {
 			issues:    issues,
 			branches:  branches,
 			remoteErr: remoteErr,
+			prOpen:    prOpen,
+			issueOpen: issueOpen,
 		}
+	}
+}
+
+func (a *App) updateRepoOpenCounts(repoPath string, prOpen *int, issueOpen *int) {
+	for i := range a.repos {
+		if a.repos[i].Path != repoPath {
+			continue
+		}
+		a.repos[i].PROpen = prOpen
+		a.repos[i].IssueOpen = issueOpen
+		return
 	}
 }
 

--- a/internal/tui/app_flow_test.go
+++ b/internal/tui/app_flow_test.go
@@ -14,9 +14,9 @@ func newTestApp() *App {
 	a.width = 120
 	a.height = 40
 	a.repos = []model.RepoStatus{
-		{Name: "repo-a", Branch: "main", Sync: model.SyncSynced},
-		{Name: "repo-b", Branch: "dev", Sync: model.SyncAhead, Ahead: 2},
-		{Name: "repo-c", Branch: "feat", Sync: model.SyncBehind, Behind: 1},
+		{Name: "repo-a", Path: "/tmp/repo-a", Branch: "main", Sync: model.SyncSynced},
+		{Name: "repo-b", Path: "/tmp/repo-b", Branch: "dev", Sync: model.SyncAhead, Ahead: 2},
+		{Name: "repo-c", Path: "/tmp/repo-c", Branch: "feat", Sync: model.SyncBehind, Behind: 1},
 	}
 	a.recomputeGrid()
 	return a
@@ -182,5 +182,27 @@ func TestJumpMatchNoMatchSafe(t *testing.T) {
 	a.jumpMatch(1)
 	if a.matchIdx != -1 {
 		t.Fatalf("matchIdx=%d", a.matchIdx)
+	}
+}
+
+func TestRemoteLoadedMsgUpdatesRepoCounters(t *testing.T) {
+	a := newTestApp()
+	a.selectedIndex = 0
+
+	prCount := 2
+	issueCount := 3
+	_, _ = a.Update(remoteLoadedMsg{
+		repoPath:  "/tmp/repo-a",
+		prs:       []model.PullRequestItem{{Number: 1}, {Number: 2}},
+		issues:    []model.IssueItem{{Number: 10}, {Number: 11}, {Number: 12}},
+		prOpen:    &prCount,
+		issueOpen: &issueCount,
+	})
+
+	if a.repos[0].PROpen == nil || *a.repos[0].PROpen != 2 {
+		t.Fatalf("pr open not updated, got=%v", a.repos[0].PROpen)
+	}
+	if a.repos[0].IssueOpen == nil || *a.repos[0].IssueOpen != 3 {
+		t.Fatalf("issue open not updated, got=%v", a.repos[0].IssueOpen)
 	}
 }


### PR DESCRIPTION
## 这次的更改 (Changes Made)
- 问题是什么：首页仓库卡片使用 `RepoStatus.PROpen/IssueOpen` 展示 PR 与 Issue 数量，但刷新链路未回填这两个字段，导致 `game_portal_react` 等仓库即使有开启 PR 也显示为 `-`。
- 解决方案是什么：
  - 在远端加载消息 `remoteLoadedMsg` 中新增 `prOpen/issueOpen`，并在 UI 更新时回写到对应仓库状态。
  - 在首页刷新流程 `refreshAllCmd` 中补充 GitHub PR/Issue 数量同步，确保不进入详情页也能正确显示计数。
  - 新增回归测试 `TestRemoteLoadedMsgUpdatesRepoCounters`，覆盖计数回填逻辑。
- 修复结论是什么：已通过 `go test ./...` 与 `go build ./...` 验证，PR/Issue 数量可在首页正确展示。

## 涉及范围 (Scope of Impact)
- TUI 首页与详情页远端数据同步逻辑：`internal/tui/app.go`
- TUI 行为回归测试：`internal/tui/app_flow_test.go`

## 有没有风险 (Risks)
- 无明显风险。
- 本次改动仅在已有 GitHub 拉取成功时补充计数赋值；鉴权失败或拉取失败仍保持原有降级行为（显示 `-`）。