### PR TITLE
fix: 修复配置文件路径安全漏洞

### DIFF
--- a/internal/workspace/scan.go
+++ b/internal/workspace/scan.go
@@ -18,6 +18,22 @@ func ScanRepos(root string, configuredPaths []string) ([]RepoDir, error) {
 	return scanDirectChildren(root)
 }
 
+func isPathTraversal(rel string) bool {
+	if rel == ".." {
+		return true
+	}
+	if strings.HasPrefix(rel, "../") {
+		return true
+	}
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return true
+	}
+	if filepath.IsAbs(rel) {
+		return true
+	}
+	return false
+}
+
 func scanConfiguredPaths(root string, paths []string) ([]RepoDir, error) {
 	// 将 root 转为绝对路径，用于后续验证
 	absRoot, err := filepath.Abs(root)
@@ -40,7 +56,7 @@ func scanConfiguredPaths(root string, paths []string) ([]RepoDir, error) {
 		if err != nil {
 			continue
 		}
-		if strings.HasPrefix(relToRoot, "..") || filepath.IsAbs(relToRoot) {
+		if isPathTraversal(relToRoot) {
 			continue
 		}
 

--- a/internal/workspace/scan_test.go
+++ b/internal/workspace/scan_test.go
@@ -154,3 +154,20 @@ func TestScanReposRejectsPathTraversal(t *testing.T) {
 		t.Fatalf("should reject path traversal, got %d repos", len(repos))
 	}
 }
+
+func TestScanReposAcceptsDotDotPrefixDir(t *testing.T) {
+	root := t.TempDir()
+	dotDotCache := filepath.Join(root, "..cache", "repo")
+	_ = os.MkdirAll(filepath.Join(dotDotCache, ".git"), 0o755)
+
+	repos, err := ScanRepos(root, []string{"..cache/repo"})
+	if err != nil {
+		t.Fatalf("scan failed: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("should accept dir starting with .., got %d repos", len(repos))
+	}
+	if repos[0].Path != dotDotCache {
+		t.Fatalf("path = %s, want %s", repos[0].Path, dotDotCache)
+	}
+}


### PR DESCRIPTION
## 这次的更改

- 修复 PR #5 评审中指出的安全漏洞
- `scanConfiguredPaths` 函数添加路径验证，防止配置文件中的路径逃逸 workspace 根目录

### 问题是什么
`scanConfiguredPaths` 函数直接信任配置文件中的路径，没有验证路径是否在 workspace 根目录内：
- 绝对路径（如 `/home/user/secret-repo`）会被接受
- 路径遍历（如 `../../secret-repo`）会被接受

这导致用户可能访问/修改 workspace 之外的仓库。

### 解决方案是什么
1. 拒绝配置中的绝对路径（`filepath.IsAbs` 检查）
2. 验证最终路径必须在 workspace 根目录内（通过 `filepath.Rel` 检查相对路径是否以 `..` 开头）

### 修复结论是什么
添加了安全验证逻辑和对应的测试用例：
- `TestScanReposRejectsAbsolutePath`: 验证绝对路径被拒绝
- `TestScanReposRejectsPathTraversal`: 验证路径遍历被拒绝

## 涉及范围

- `internal/workspace/scan.go` — 添加路径安全验证
- `internal/workspace/scan_test.go` — 添加安全测试用例

## 有没有风险

无明显风险。修改是严格的安全加强，不影响正常使用场景（配置有效的相对路径）。