### PR TITLE
优化 TUI 界面：移除 Legend 并移动帮助提示到底部

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -389,6 +389,7 @@ func (a *App) viewHome() string {
 	repos := a.filteredRepos()
 	if len(repos) == 0 {
 		lines = append(lines, "没有仓库（可调整过滤条件）")
+		lines = append(lines, help)
 		return strings.Join(lines, "\n")
 	}
 


### PR DESCRIPTION
## 概览
本次 PR 针对 TUI 界面进行了两项优化：
1. **移除 Legend**: 用户反馈 Legend 部分（符号说明）用处不大，因此将其移除以节省屏幕空间。
2. **移动操作提示**: 将操作提示（Help/Keybindings）从屏幕顶部移动到最底部，更符合一般的 CLI 工具交互习惯。

## 这次的更改 (Changes Made)
- 删除了 `viewHome` 函数中渲染 Legend 的代码块。
- 将 `help` 变量的渲染位置从 `lines` 数组的开头移动到 `lines` 数组的末尾。

## 涉及范围 (Scope of Impact)
- 仅影响 `internal/tui/app.go` 中的 `viewHome` 函数。
- 影响主界面（Home Screen）的显示布局。

## 有没有风险 (Risks)
- **无明显风险**: 这是一个纯粹的 UI 调整，不涉及核心逻辑或数据处理。