### PR TITLE
feat(tui): 优化键盘快捷键

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -289,7 +289,7 @@ func (a *App) updateHome(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		a.selectedIndex = moveIndex(a.selectedIndex, len(visible), a.columns, "left")
 	case "right", "l":
 		a.selectedIndex = moveIndex(a.selectedIndex, len(visible), a.columns, "right")
-	case "enter":
+	case " ", "enter":
 		a.screen = screenDetail
 		a.detailTab = tabPR
 		a.detailPRIdx = 0
@@ -304,7 +304,7 @@ func (a *App) updateHome(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (a *App) updateDetail(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	current := a.currentRepo()
 	switch msg.String() {
-	case "esc", "backspace":
+	case "q", "backspace":
 		a.screen = screenHome
 		return a, nil
 	case "r":
@@ -406,7 +406,7 @@ func (a *App) viewHome() string {
 	if a.gh.Authenticated() {
 		tokenState = tokenOKStyle.Render("token: github ✓")
 	}
-	help := helpStyle.Render("↑↓←→/h j k l 选择  Enter 进入  / 过滤  r 刷新  q 退出")
+	help := helpStyle.Render("↑↓←→/h j k l 选择  Space 进入  / 过滤  r 刷新  q 退出")
 	if a.filterMode {
 		help = searchInfoStyle.Render("过滤中: ") + a.filterText + helpStyle.Render("  (Enter/ESC 结束)")
 	}
@@ -501,7 +501,7 @@ func (a *App) viewDetail() string {
 	header := titleStyle.Render(repo.Name) + " " +
 		labelDimStyle.Render("(branch: ") + repo.Branch +
 		labelDimStyle.Render("  status: ") + renderSyncColored(repo.Sync, repo.Ahead, repo.Behind) +
-		labelDimStyle.Render(")") + "  " + helpStyle.Render("[Esc] back")
+		labelDimStyle.Render(")") + "  " + helpStyle.Render("[q] back")
 
 	tabLabels := []string{"PRs", "Issues", "Branches"}
 	tabStrs := make([]string, len(tabLabels))

--- a/internal/tui/app_flow_test.go
+++ b/internal/tui/app_flow_test.go
@@ -44,7 +44,7 @@ func TestUpdateHomeNavigation(t *testing.T) {
 
 func TestUpdateHomeEnterToDetail(t *testing.T) {
 	a := newTestApp()
-	_, cmd := a.updateHome(tea.KeyMsg{Type: tea.KeyEnter})
+	_, cmd := a.updateHome(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
 	if a.screen != screenDetail {
 		t.Fatalf("expected detail screen")
 	}
@@ -88,7 +88,7 @@ func TestUpdateDetailTabSwitch(t *testing.T) {
 func TestUpdateDetailBackHome(t *testing.T) {
 	a := newTestApp()
 	a.screen = screenDetail
-	_, _ = a.updateDetail(tea.KeyMsg{Type: tea.KeyEsc})
+	_, _ = a.updateDetail(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	if a.screen != screenHome {
 		t.Fatalf("expected home")
 	}


### PR DESCRIPTION
## 这次的更改

- **详情页退出改用 q 键**：原来需要按 Esc 返回首页，现在改为 q 键，与主页的退出操作保持一致，操作更统一
- **首页进入详情支持 Space 键**：原来只能用 Enter 进入详情，现在同时支持 Space 键，与分支 tab 中 Space 切换分支的操作风格统一

## 涉及范围

- `internal/tui/app.go`：键盘事件处理和帮助文本
- `internal/tui/app_flow_test.go`：相关测试用例

## 有没有风险

无明显风险，仅修改键盘快捷键映射，不影响核心功能逻辑。所有测试通过。