### PR TITLE
fix: 刷新时不显示'没有仓库'提示

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -420,7 +420,7 @@ func (a *App) viewHome() string {
 	}
 
 	repos := a.filteredRepos()
-	if len(repos) == 0 {
+	if len(repos) == 0 && !a.loading {
 		lines = append(lines, "没有仓库（可调整过滤条件）")
 		lines = append(lines, help)
 		return strings.Join(lines, "\n")


### PR DESCRIPTION
## 这次的更改 (Changes Made)

修复了刷新时显示"没有仓库"提示的问题。

- **问题是什么**: 当用户按 `r` 刷新时，`loading` 被设置为 `true`，但如果此时 `repos` 为空，会显示"没有仓库（可调整过滤条件）"，这给用户造成困惑。

- **解决方案是什么**: 在判断是否显示"没有仓库"的条件中添加 `!a.loading` 检查，确保只有在非加载状态且确实没有仓库时才显示该提示。

- **修复结论是什么**: 刷新过程中不再显示误导性的"没有仓库"提示，用户体验更加流畅。

## 涉及范围 (Scope of Impact)

- `internal/tui/app.go` - 修改了 `viewHome()` 函数中的条件判断逻辑

## 有没有风险 (Risks)

无明显风险。这是一个简单的条件判断修复，不影响其他功能。