### PR TITLE
refactor: 统一卡片状态显示到 branch 右边

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -487,10 +487,9 @@ func (a *App) renderCard(repo model.RepoStatus, selected bool) string {
 		errMark = errStyle.Render(" !" + string(repo.Error))
 	}
 
-	line1 := nameStr + "  " + syncStr + dirtyStr
-	line2 := labelDimStyle.Render("branch: ") + repo.Branch
-	line3 := renderSyncColored(repo.Sync, repo.Ahead, repo.Behind) + "  " +
-		prLabelStyle.Render("PR ") + pr + "  " +
+	line1 := nameStr + dirtyStr
+	line2 := labelDimStyle.Render("branch: ") + repo.Branch + "  " + syncStr
+	line3 := prLabelStyle.Render("PR ") + pr + "  " +
 		issueLabelStyle.Render("Issues ") + issue + errMark
 
 	return s.Render(line1 + "\n" + line2 + "\n" + line3)


### PR DESCRIPTION
## 这次的更改 (Changes Made)

统一了卡片中状态显示的位置，消除了重复显示。

- **问题是什么**: 卡片标题右边有状态（同步状态），卡片下也有状态显示，这个状态显示冲突了，造成视觉混乱。

- **解决方案是什么**: 
  - 第一行：仓库名 + 修改标记（移除同步状态）
  - 第二行：branch: xxx + 同步状态（统一显示在 branch 右边）
  - 第三行：PR数 + Issues数 + 错误标记（移除重复的同步状态）

- **修复结论是什么**: 同步状态只在 branch 行显示一次，布局更清晰，信息层级更明确。

## 涉及范围 (Scope of Impact)

- `internal/tui/app.go` - 修改了 `renderCard()` 函数的布局

## 有没有风险 (Risks)

无明显风险。这是一个纯粹的布局调整，不影响功能逻辑。