### PR TITLE
fix: f/F pull 后立即刷新卡片状态

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -207,16 +207,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, tea.Batch(a.refreshAllCmd(), a.loadRemoteCmd(m.repo))
 
 	case pullDoneMsg:
-		a.loading = false
 		if m.err != nil {
 			a.errText = "pull 失败: " + m.err.Error()
-			return a, nil
+		} else {
+			a.errText = ""
 		}
-		a.errText = ""
 		return a, a.refreshAllCmd()
 
 	case pullAllDoneMsg:
-		a.loading = false
 		if m.failed > 0 && m.lastErr != nil {
 			a.errText = fmt.Sprintf("pull 完成: %d 成功, %d 失败 (%s)", m.completed, m.failed, m.lastErr.Error())
 		} else {


### PR DESCRIPTION
## 这次的更改 (Changes Made)

修复了使用 f/F 快捷键 pull 代码后，卡片状态没有立即刷新的问题。

### 问题是什么
- 使用 `f` (pull 当前仓库) 或 `F` (pull 全部仓库) 后，卡片的同步状态（如 ↓3 → ✓）没有立即更新
- "更新中"提示消失后，还需要等待一段时间卡片才会刷新

### 解决方案是什么
- 移除 `pullDoneMsg` 和 `pullAllDoneMsg` 中的 `loading = false`
- 让 `refreshDoneMsg` 统一处理 `loading` 状态
- 这样 "更新中" 会持续显示直到 `refreshAllCmd()` 完成并更新卡片

### 修复结论是什么
- 现在 f/F pull 后，"更新中"会持续显示直到卡片状态真正刷新完成
- 用户体验更一致，不会出现 loading 消失但卡片还没更新的情况
- 同时修复了 pull 失败时不刷新状态的问题

## 涉及范围 (Scope of Impact)
- `internal/tui/app.go`: 修改 `pullDoneMsg` 和 `pullAllDoneMsg` 的处理逻辑

## 有没有风险 (Risks)
无明显风险。修改量小，逻辑清晰，只影响 pull 操作后的状态刷新时机。