### PR TITLE
feat: 优化 diff 文件列表滚动体验

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1033,15 +1033,29 @@ func (a *App) renderFileTree(width, height int) string {
 	}
 
 	// Calculate vertical scroll based on selected line position
+	// Scroll when selection reaches 1/3 of visible height from top
 	if totalLines <= height {
 		a.diffLeftOffset = 0
 	} else {
-		// Keep selected line visible
-		if selectedLineIdx < a.diffLeftOffset {
-			a.diffLeftOffset = selectedLineIdx
-		} else if selectedLineIdx >= a.diffLeftOffset+height {
-			a.diffLeftOffset = selectedLineIdx - height + 1
+		// Calculate threshold at 1/3 of height
+		threshold := height / 3
+		if threshold < 1 {
+			threshold = 1
 		}
+
+		// Scroll up when selection moves above threshold from top
+		if selectedLineIdx < a.diffLeftOffset+threshold {
+			a.diffLeftOffset = selectedLineIdx - threshold
+			if a.diffLeftOffset < 0 {
+				a.diffLeftOffset = 0
+			}
+		}
+
+		// Scroll down when selection moves below threshold from bottom
+		if selectedLineIdx >= a.diffLeftOffset+height-threshold {
+			a.diffLeftOffset = selectedLineIdx - height + threshold + 1
+		}
+
 		// Ensure we don't scroll past the end
 		if a.diffLeftOffset+height > totalLines {
 			a.diffLeftOffset = totalLines - height


### PR DESCRIPTION
## 这次的更改

将左侧文件树的滚动触发阈值从可视区域底部边缘调整到底部 1/3 位置。

**问题是什么**: 之前在 diff 视图浏览文件列表时，需要滚动到列表最底部边缘才会触发跟随滚动，体验不够流畅。

**解决方案是什么**: 将滚动触发点改为到达可视区域底部 1/3 位置时就开始跟随滚动。

**修复结论是什么**: 浏览文件列表时滚动跟随更加自然流畅。

## 涉及范围

- `internal/tui/app.go` 中 `renderFileTree` 函数的滚动逻辑

## 有没有风险

无明显风险。修改仅涉及 UI 滚动行为，不影响任何业务逻辑。