### PR TITLE
优化 TUI 刷新机制：工作区与仓库独立更新

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -98,6 +98,7 @@ type App struct {
 	refreshSeq    int
 
 	workspaces         []string
+	reposWorkspace     string
 	workspaceCounts    map[string]int
 	workspaceHasUpdate map[string]bool
 	workspaceChecking  map[string]bool
@@ -226,13 +227,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		a.errText = ""
+		repoDirs := dedupeRepoDirsByPath(m.repos)
 		existing := make(map[string]model.RepoStatus, len(a.repos))
 		for _, repo := range a.repos {
 			existing[repo.Path] = repo
 		}
 
-		nextRepos := make([]model.RepoStatus, 0, len(m.repos))
-		for _, repo := range m.repos {
+		nextRepos := make([]model.RepoStatus, 0, len(repoDirs))
+		for _, repo := range repoDirs {
 			if prev, ok := existing[repo.Path]; ok {
 				prev.Name = repo.Name
 				prev.Path = repo.Path
@@ -1300,16 +1302,22 @@ func (a *App) refreshAllCmd() tea.Cmd {
 	a.refreshSeq++
 	seq := a.refreshSeq
 	a.loading = true
+	a.repoRefreshing = make(map[string]bool)
+	a.repoRefreshPending = 0
 
 	if len(a.workspaces) == 0 || a.selectedWsIndex >= len(a.workspaces) {
 		a.repos = []model.RepoStatus{}
-		a.repoRefreshing = make(map[string]bool)
-		a.repoRefreshPending = 0
+		a.reposWorkspace = ""
 		a.loading = false
 		return nil
 	}
 
 	wsName := a.workspaces[a.selectedWsIndex]
+	if wsName != a.reposWorkspace {
+		a.repos = []model.RepoStatus{}
+		a.selectedIndex = 0
+	}
+	a.reposWorkspace = wsName
 	paths := append([]string(nil), a.cfg.Global.Workspaces[wsName]...)
 
 	return func() tea.Msg {
@@ -1356,6 +1364,19 @@ func (a *App) updateRepoStatus(status model.RepoStatus) {
 		a.repos[i] = status
 		return
 	}
+}
+
+func dedupeRepoDirsByPath(repos []workspace.RepoDir) []workspace.RepoDir {
+	seen := make(map[string]struct{}, len(repos))
+	out := make([]workspace.RepoDir, 0, len(repos))
+	for _, repo := range repos {
+		if _, ok := seen[repo.Path]; ok {
+			continue
+		}
+		seen[repo.Path] = struct{}{}
+		out = append(out, repo)
+	}
+	return out
 }
 
 func (a *App) loadRemoteCmd(repo model.RepoStatus) tea.Cmd {

--- a/internal/tui/app_flow_test.go
+++ b/internal/tui/app_flow_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Fairfarren/peekgit/internal/config"
 	"github.com/Fairfarren/peekgit/internal/model"
+	"github.com/Fairfarren/peekgit/internal/workspace"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -428,5 +429,54 @@ func TestWorkspaceCheckCmdStartsOnlyIdleWorkspaceChecks(t *testing.T) {
 	}
 	if !a.workspaceChecking["ws-b"] {
 		t.Fatalf("expected ws-b checking state to become true")
+	}
+}
+
+func TestRefreshAllCmdClearsReposWhenWorkspaceSwitched(t *testing.T) {
+	a := New(config.Config{
+		Global: config.GlobalConfig{Workspaces: map[string][]string{
+			"ws-a": {"/tmp"},
+			"ws-b": {"/tmp"},
+		}},
+		IntervalSec: 300,
+		Concurrency: 1,
+		NoGitHub:    true,
+	})
+
+	a.reposWorkspace = "ws-a"
+	a.repos = []model.RepoStatus{{Name: "old", Path: "/tmp/old", Sync: model.SyncSynced}}
+	a.selectedWsIndex = 1
+
+	cmd := a.refreshAllCmd()
+
+	if cmd == nil {
+		t.Fatalf("expected refresh command")
+	}
+	if len(a.repos) != 0 {
+		t.Fatalf("expected stale repos to be cleared when switching workspace")
+	}
+}
+
+func TestRefreshDoneMsgDeduplicatesReposByPath(t *testing.T) {
+	a := newTestApp()
+	a.refreshSeq = 5
+	a.repos = nil
+
+	_, cmd := a.Update(refreshDoneMsg{
+		seq: 5,
+		repos: []workspace.RepoDir{
+			{Name: "repo-1", Path: "/tmp/repo-1"},
+			{Name: "repo-1-dup", Path: "/tmp/repo-1"},
+		},
+	})
+
+	if cmd == nil {
+		t.Fatalf("expected follow-up refresh commands")
+	}
+	if len(a.repos) != 1 {
+		t.Fatalf("expected duplicate paths to be deduplicated, got %d", len(a.repos))
+	}
+	if a.repoRefreshPending != 1 {
+		t.Fatalf("expected pending count to match deduplicated repos, got %d", a.repoRefreshPending)
 	}
 }


### PR DESCRIPTION
## 这次的更改 (Changes Made)
- 将 workspace 检查从全局状态改为按 workspace 独立追踪：每个 workspace 独立请求、独立返回、独立更新卡片状态。
- 将 Home 页仓库刷新改为两阶段：先扫描仓库列表，再按 repo 并发刷新并逐条回写 UI，避免等待整批完成后才更新。
- 新增刷新序列号与并发限流，避免过期刷新结果污染当前 UI 状态；并在卡片上显示逐项刷新中的状态。
- 调整并补充 `internal/tui/app_flow_test.go` 测试，覆盖“单项完成只更新单项”和“刷新中保留已有卡片展示”等关键行为。

## 涉及范围 (Scope of Impact)
- `internal/tui/app.go`
- `internal/tui/app_flow_test.go`
- 影响界面：Workspace 卡片视图、Home 仓库卡片视图的刷新与状态展示逻辑。

## 有没有风险 (Risks)
- 并发与状态机复杂度提升，主要风险在于刷新时序与过期消息处理。
- 已通过 `go test ./...`、`go test ./... -coverprofile=coverage.out` 与 `go build ./cmd/repo-monitor` 验证，当前无明显风险。