### PR TITLE
fix: 恢复单仓库配置方案

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,13 +58,13 @@ changelog:
       - Merge pull request
       - Merge branch
 
-# Homebrew Tap 配置 - 发布到独立的 Tap 仓库
+# Homebrew Tap 配置 - 发布到当前仓库的 Formula/ 目录
 brews:
   - name: peekgit
     repository:
       owner: Fairfarren
-      name: homebrew-peekgit
-      branch: main
+      name: peekgit
+      branch: master
     directory: Formula
     homepage: https://github.com/Fairfarren/peekgit
     description: 终端里的多仓库监控面板。一次性查看 workspace 下所有 Git 仓库的分支状态、同步情况，以及 GitHub PR / Issues。
@@ -77,14 +77,15 @@ brews:
     commit_msg_template: "chore(release): brew formula for {{ .Tag }}"
     install: |-
       bin.install "repo-monitor"
-# Scoop Bucket 配置 - 发布到独立的 Bucket 仓库
+
+# Scoop Bucket 配置 - 发布到当前仓库的 scoop/ 目录
 scoops:
   - name: peekgit
     repository:
       owner: Fairfarren
-      name: scoop-peekgit
-      branch: main
-    directory: .
+      name: peekgit
+      branch: master
+    directory: scoop
     homepage: https://github.com/Fairfarren/peekgit
     description: 终端里的多仓库监控面板。一次性查看 workspace 下所有 Git 仓库的分支状态、同步情况，以及 GitHub PR / Issues。
     license: MIT

--- a/README.md
+++ b/README.md
@@ -7,15 +7,13 @@
 ### Homebrew (推荐 - macOS/Linux)
 
 ```bash
-brew tap Fairfarren/peekgit
-brew install peekgit
+brew install https://raw.githubusercontent.com/Fairfarren/peekgit/master/Formula/peekgit.rb
 ```
 
 ### Scoop (推荐 - Windows)
 
 ```powershell
-scoop bucket add peekgit https://github.com/Fairfarren/scoop-peekgit
-scoop install peekgit
+scoop install https://raw.githubusercontent.com/Fairfarren/peekgit/master/scoop/peekgit.json
 ```
 
 ### Go install


### PR DESCRIPTION
## 更改内容

- 恢复 GoReleaser 配置指向主仓库的 `Formula/` 和 `scoop/` 目录
- 更新 README 安装命令为 raw URL 方式
- 关闭了之前的 PR #32（独立 Tap/Bucket 方案）

## 优点

- ✅ 不需要额外的 Tap/Bucket 仓库
- ✅ 不需要 PAT，使用默认 GITHUB_TOKEN 即可
- ✅ 维护更简单，只需管理一个仓库

## 安装命令

### Homebrew (macOS/Linux)
```bash
brew install https://raw.githubusercontent.com/Fairfarren/peekgit/master/Formula/peekgit.rb
```

### Scoop (Windows)
```powershell
scoop install https://raw.githubusercontent.com/Fairfarren/peekgit/master/scoop/peekgit.json
```

AI Sisyphus Review