### PR TITLE
feat: 将命令名从 repo-monitor 改为 peekgit

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,9 +8,9 @@ before:
     - go mod tidy
 
 builds:
-  - id: repo-monitor
+  - id: peekgit
     main: ./cmd/repo-monitor
-    binary: repo-monitor
+    binary: peekgit
     env:
       - CGO_ENABLED=0
     goos:
@@ -27,9 +27,9 @@ builds:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
 
 archives:
-  - id: repo-monitor
+  - id: peekgit
     builds:
-      - repo-monitor
+      - peekgit
     format: tar.gz
     format_overrides:
       - goos: windows
@@ -70,13 +70,13 @@ brews:
     description: 终端里的多仓库监控面板。一次性查看 workspace 下所有 Git 仓库的分支状态、同步情况，以及 GitHub PR / Issues。
     license: MIT
     test: |
-      system "#{bin}/repo-monitor --help"
+      system "#{bin}/peekgit --help"
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "chore(release): brew formula for {{ .Tag }}"
     install: |-
-      bin.install "repo-monitor"
+      bin.install "peekgit"
 
 # Scoop Bucket 配置 - 发布到当前仓库的 scoop/ 目录
 scoops:

--- a/Formula/peekgit.rb
+++ b/Formula/peekgit.rb
@@ -14,7 +14,7 @@ class Peekgit < Formula
       sha256 "704f297db968b9055c6e4bc20b18c44ad79a8e8ae9a380cfc5ffbeaf56c71632"
 
       define_method(:install) do
-        bin.install "repo-monitor"
+        bin.install "peekgit"
       end
     end
     if Hardware::CPU.arm?
@@ -22,7 +22,7 @@ class Peekgit < Formula
       sha256 "d4d6227163ea4fcff025594f74d4e321d21135657e483af2298db5e0c78fcfcd"
 
       define_method(:install) do
-        bin.install "repo-monitor"
+        bin.install "peekgit"
       end
     end
   end
@@ -32,19 +32,19 @@ class Peekgit < Formula
       url "https://github.com/Fairfarren/peekgit/releases/download/v0.1.0/peekgit_linux_x86_64.tar.gz"
       sha256 "b47c9ef872e507334853a0f06ac02815fc261f57d1ad93cf35ecb88d73d5eb73"
       define_method(:install) do
-        bin.install "repo-monitor"
+        bin.install "peekgit"
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/Fairfarren/peekgit/releases/download/v0.1.0/peekgit_linux_arm64.tar.gz"
       sha256 "1206af80f1ebbe14527f37e9ba75f7e63899609511ac82f2dcb6743a7b95e853"
       define_method(:install) do
-        bin.install "repo-monitor"
+        bin.install "peekgit"
       end
     end
   end
 
   test do
-    system "#{bin}/repo-monitor --help"
+    system "#{bin}/peekgit --help"
   end
 end

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ go install github.com/Fairfarren/peekgit/cmd/repo-monitor@latest
 ```bash
 git clone https://github.com/Fairfarren/peekgit.git
 cd peekgit
-go build -o repo-monitor ./cmd/repo-monitor
+go build -o peekgit ./cmd/repo-monitor
 ```
 
 ## 快速开始
@@ -35,7 +35,7 @@ go build -o repo-monitor ./cmd/repo-monitor
 配置好 `~/.config/peekgit/config.json` 后，在任意目录直接运行：
 
 ```bash
-repo-monitor
+peekgit
 ```
 
 程序启动后会先进入启动页，包含三个标签：`workspace`、`pr`、`issues`。
@@ -53,7 +53,7 @@ repo-monitor
 | `--no-github` | false | 禁用 GitHub 功能（PR、Issues） |
 
 ```bash
-repo-monitor --interval 60 --concurrency 5
+peekgit --interval 60 --concurrency 5
 ```
 
 ## 全局配置文件

--- a/scoop/peekgit.json
+++ b/scoop/peekgit.json
@@ -4,7 +4,7 @@
         "64bit": {
             "url": "https://github.com/Fairfarren/peekgit/releases/download/v0.1.0/peekgit_windows_x86_64.zip",
             "bin": [
-                "repo-monitor.exe"
+                "peekgit.exe"
             ],
             "hash": "36e89e62943ce74ce85ad94182f83f1ea9d08fb1f336629c467f459c49c1cd5a"
         }


### PR DESCRIPTION
## 这次的更改

将命令行工具的名称从 `repo-monitor` 改为 `peekgit`，使命令名与项目名保持一致。

### 具体修改

- `.goreleaser.yaml`: 将 build id 和 binary 名称从 `repo-monitor` 改为 `peekgit`
- `Formula/peekgit.rb`: 更新 Homebrew 安装的二进制名
- `scoop/peekgit.json`: 更新 Windows Scoop 安装的二进制名
- `README.md`: 更新文档中的所有命令示例

## 涉及范围

- 构建配置文件
- 包管理器配置（Homebrew、Scoop）
- 项目文档

## 有没有风险

无明显风险。这是一个纯粹的命名更改，不涉及功能逻辑的修改。