### PR TITLE
fix: update CLI name display in help message

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,7 +63,7 @@ func LoadGlobalConfig() (GlobalConfig, error) {
 }
 
 func Parse(args []string) (Config, error) {
-	fs := flag.NewFlagSet("repo-monitor", flag.ContinueOnError)
+	fs := flag.NewFlagSet("peekgit", flag.ContinueOnError)
 	interval := fs.Int("interval", DefaultIntervalSec, "refresh interval in seconds")
 	concurrency := fs.Int("concurrency", DefaultConcurrency, "fetch concurrency")
 	noGitHub := fs.Bool("no-github", false, "disable GitHub features")


### PR DESCRIPTION
Fix the flag set name from 'repo-monitor' to 'peekgit' in help message