### PR TITLE
fix(ci): 移除 PR 合并后的重复 CI 运行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
## 这次的更改 (Changes Made)

移除了 `.github/workflows/ci.yml` 中的 `push` 触发器，只保留 `pull_request` 触发。

### 问题是什么

PR 合并后，`push` 事件会再次触发 test CI，导致：
- 重复运行已经测试过的代码
- 浪费 CI 资源
- 增加不必要的等待时间

### 解决方案是什么

移除 `push` 触发器配置，只保留 `pull_request` 触发。

修改前：
```yaml
on:
  push:
    branches:
      - main
      - master
  pull_request:
```

修改后：
```yaml
on:
  pull_request:
```

### 修复结论是什么

- ✓ PR 创建/更新时 → 运行 test CI（保证代码质量）
- ✓ PR 合并后 → 不再运行 test CI（避免重复测试）
- ✓ Release workflow 独立运行，不受影响

## 涉及范围 (Scope of Impact)

- 仅影响 `.github/workflows/ci.yml` 文件
- 只影响 test CI 的触发条件
- 不影响 release workflow 的运行

## 有没有风险 (Risks)

无明显风险。Release workflow 在 master 分支有独立的处理逻辑，不依赖 test CI 的 push 触发。