### PR TITLE
fix(ci): 禁用 GoReleaser 自动创建 PR 功能

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,11 +66,7 @@ brews:
       name: peekgit
       branch: "{{ .ProjectName }}-{{ .Version }}"
       pull_request:
-        enabled: true
-        base:
-          owner: Fairfarren
-          name: peekgit
-          branch: master
+        enabled: false
     directory: Formula
     homepage: https://github.com/Fairfarren/peekgit
     description: 终端里的多仓库监控面板。一次性查看 workspace 下所有 Git 仓库的分支状态、同步情况，以及 GitHub PR / Issues。
@@ -92,11 +88,7 @@ scoops:
       name: peekgit
       branch: "{{ .ProjectName }}-{{ .Version }}"
       pull_request:
-        enabled: true
-        base:
-          owner: Fairfarren
-          name: peekgit
-          branch: master
+        enabled: false
     directory: scoop
     homepage: https://github.com/Fairfarren/peekgit
     description: 终端里的多仓库监控面板。一次性查看 workspace 下所有 Git 仓库的分支状态、同步情况，以及 GitHub PR / Issues。


### PR DESCRIPTION
## 这次的更改

修复 CI 发布流程失败的问题。GitHub Actions 默认没有权限创建 Pull Request，导致 GoReleaser 在发布时失败。

### 问题是什么
CI 报错：
```
403 GitHub Actions is not permitted to create or approve pull requests
```

错误发生在 GoReleaser 尝试为 Homebrew formula 和 Scoop manifest 创建 PR 时。

### 解决方案是什么
将 `.goreleaser.yaml` 中 Homebrew 和 Scoop 配置的 `pull_request.enabled` 从 `true` 改为 `false`：
- 移除了 `brews[].repository.pull_request.enabled: true` 及相关 base 配置
- 移除了 `scoops[].repository.pull_request.enabled: true` 及相关 base 配置

这样 GoReleaser 会直接推送到分支（如 `peekgit-0.1.5`），而不会尝试创建 PR。

### 修复结论是什么
发布流程将不再尝试创建 PR，避免权限错误。发布后分支会被推送到远程，用户可以手动创建 PR 合并 Homebrew 和 Scoop 配置。

## 涉及范围
- `.goreleaser.yaml` 配置文件

## 有没有风险
无明显风险。这只是改变了发布流程的行为，从"自动创建 PR"变为"直接推送分支"。发布本身的功能不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)