### PR TITLE
fix(ci): 禁用 GoReleaser 的 PR 创建功能以解决权限错误

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,7 +66,7 @@ brews:
       name: peekgit
       branch: "{{ .ProjectName }}-{{ .Version }}"
       pull_request:
-        enabled: true
+        enabled: false
         base:
           owner: Fairfarren
           name: peekgit
@@ -92,7 +92,7 @@ scoops:
       name: peekgit
       branch: "{{ .ProjectName }}-{{ .Version }}"
       pull_request:
-        enabled: true
+        enabled: false
         base:
           owner: Fairfarren
           name: peekgit


### PR DESCRIPTION
## 这次的更改

修复 CI 发布流程失败的问题。

### 问题是什么
GitHub Actions 默认的 `GITHUB_TOKEN` 不允许创建 Pull Request，导致 release 流程在创建 Homebrew Formula 和 Scoop Manifest 的 PR 时失败，错误信息：
```
403 GitHub Actions is not permitted to create or approve pull requests
```

### 解决方案是什么
将 `.goreleaser.yaml` 中的 `pull_request.enabled` 从 `true` 改为 `false`，让 GoReleaser 直接推送到分支而不创建 PR。

### 修复结论是什么
- Homebrew Formula 和 Scoop Manifest 将直接推送到对应的分支
- 避免了 GitHub Actions 权限限制导致的发布失败

## 涉及范围
- `.goreleaser.yaml` 配置文件
  - `brews` 部分的 `pull_request.enabled`
  - `scoops` 部分的 `pull_request.enabled`

## 有没有风险
无明显风险。GoReleaser 仍会创建分支并推送更新，只是不再尝试创建 PR，这符合当前仓库的权限设置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)