### PR TITLE
修正 Homebrew Tap 发布目标仓库

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,18 +58,18 @@ changelog:
       - Merge pull request
       - Merge branch
 
-# Homebrew Tap 配置 - 发布到当前仓库的 Formula/ 目录
+# Homebrew Tap 配置 - 发布到 Fairfarren/homebrew-tap 仓库
 brews:
   - name: peekgit
     repository:
       owner: Fairfarren
-      name: peekgit
+      name: homebrew-tap
       branch: "{{ .ProjectName }}-{{ .Version }}"
       pull_request:
         enabled: true
         base:
           owner: Fairfarren
-          name: peekgit
+          name: homebrew-tap
           branch: master
     directory: Formula
     homepage: https://github.com/Fairfarren/peekgit


### PR DESCRIPTION
## 这次的更改

**问题是什么**：GoReleaser 配置将 Homebrew formula 发布到 `Fairfarren/peekgit` 仓库，但用户通过 `brew tap Fairfarren/tap` 安装，该 tap 是独立的 `Fairfarren/homebrew-tap` 仓库。导致用户安装的版本落后（0.1.0 vs 0.1.5）。

**解决方案是什么**：修改 `.goreleaser.yaml` 中的 `brews.repository` 配置，将 formula 发布到正确的 `Fairfarren/homebrew-tap` 仓库。

**修复结论是什么**：合并此 PR 后，下次发布新版本时，GoReleaser 会自动将 formula 更新到正确的 tap 仓库，用户可以通过现有安装命令获取最新版本。

## 涉及范围

- `.goreleaser.yaml`：修改 `brews` 配置的目标仓库

## 有没有风险

无明显风险。修改仅影响发布流程，不影响现有功能代码。