### PR TITLE
fix(ci): use github app token for go-releaser and fix ref checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: master
-      
+          ref: ${{ github.ref }}
+
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: stable
-      
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -34,7 +41,7 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   # 自动 patch 版本发布 - 当推送到 master 分支且不是 release commit 或 GoReleaser PR 合并时触发
   auto-patch-release:
@@ -45,14 +52,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Get current version and create new patch version
         id: get-version
         run: |
           # 获取最新标签
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "Latest tag: $LATEST_TAG"
-          
+
           # 提取版本号并递增 patch 版本
           VERSION=$(echo $LATEST_TAG | sed 's/v//')
           MAJOR=$(echo $VERSION | cut -d'.' -f1)
@@ -60,25 +67,38 @@ jobs:
           PATCH=$(echo $VERSION | cut -d'.' -f3)
           NEW_PATCH=$((PATCH + 1))
           NEW_VERSION="v${MAJOR}.${MINOR}.${NEW_PATCH}"
-          
+
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "Creating new patch version: $NEW_VERSION"
-      
+
       - name: Configure git
         run: |
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
-      
+
       - name: Create and push new patch tag
         run: |
           git tag ${{ steps.get-version.outputs.new_version }}
           git push origin ${{ steps.get-version.outputs.new_version }}
-      
+
+      - name: Checkout Tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.get-version.outputs.new_version }}
+
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: stable
-      
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -86,4 +106,4 @@ jobs:
           version: "~> v2"
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This PR fixes the CI/CD workflow by using the newly configured GitHub App token to bypass branch protection rules for GoReleaser, and fixes the incorrectly hardcoded branch checkouts.