### PR TITLE
ci: 合并 Homebrew/Scoop 构建提交并消除幽灵 Action 记录

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,3 +88,19 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Commit and push manifest updates
+        run: |
+          # 复制生成的两个文件回到主仓库对应的位置
+          # GoReleaser 默认在 dist/<directory>/<name>.<ext> 生成文件
+          cp dist/Formula/peekgit.rb Formula/
+          cp dist/scoop/peekgit.json scoop/
+
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+          git add Formula/peekgit.rb scoop/peekgit.json
+          git commit -m "chore(release): update brew formula and scoop manifest [skip ci]" || echo "No changes to commit"
+
+          # 推送到 master 分支
+          git push origin HEAD:master

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,6 +76,7 @@ brews:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "chore(release): brew formula for {{ .Tag }}"
+    skip_upload: true
     install: |-
       bin.install "peekgit"
 
@@ -94,3 +95,4 @@ scoops:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "chore(release): scoop manifest for {{ .Tag }}"
+    skip_upload: true


### PR DESCRIPTION
## 优化内容清单

1. **禁用 GoReleaser 自带推送**：修改了 `.goreleaser.yaml`，现在构建工具仅在本地生成 Brew Formula 和 Scoop Manifest 文件，不再独立发起两次 Commit 推送。
2. **合并 Commit 逻辑**：在 `release.yml` 中新加了一个任务步骤，手动将上述两个文件的更新合并为一个 Commit。
3. **彻底清理 Actions 列表**：在合并后的 Commit Message 中加入了 `[skip ci]` 标识。

## 达成效果

- **消除多余记录**：GitHub Actions 的运行列表将不再出现由 GoReleaser 副作用产生的“已跳过”运行记录（即之前看到的第 3、4 个 Action）。
- **统一原子提交**：软件版本发布、包管理器配置更新现在都在一个清晰的逻辑链路内完成。
  
合并此 PR 后，每次发布流程将仅剩下两条干净的绿色对勾执行记录。