### PR TITLE
ci: 统一优化 Release 流程与 Manifest 合并提交 (全新修复版)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,10 +91,10 @@ jobs:
 
       - name: Commit and push manifest updates
         run: |
-          # 复制生成的两个文件回到主仓库对应的位置
-          # GoReleaser 默认在 dist/<directory>/<name>.<ext> 生成文件
-          cp dist/Formula/peekgit.rb Formula/
-          cp dist/scoop/peekgit.json scoop/
+          # 动态搜索并复制生成的两个文件回到主仓库对应的位置
+          # 这样无论 GoReleaser 的子路径如何变化都能准确定位
+          find dist -name "peekgit.rb" -exec cp {} Formula/ \;
+          find dist -name "peekgit.json" -exec cp {} scoop/ \;
 
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -96,3 +96,4 @@ scoops:
       email: bot@goreleaser.com
     commit_msg_template: "chore(release): scoop manifest for {{ .Tag }}"
     skip_upload: true
+    skip_upload: true


### PR DESCRIPTION
## 优化与修复内容

由于之前尝试中遇到路径报错，我在此重新创建了一个干净的、修复后的版本：

### 1. 核心流程重构
- **各司其职**：拆分为 `auto-patch-tag` (打标签) 和 `release` (正式发布) 两个阶段，解决 PR 合并时触发两次构建的问题。
- **权限闭环**：使用 GitHub App Token 触发标签推送，确保整个流水线能自动接力。

### 2. Manifest 提交优化
- **合并提交**：将 Homebrew 和 Scoop 的更新合并在同一个 Commit 中。
- **静默推送**：由于在 Commit Message 中加入了 `[skip ci]`，发布后**不会**再产生额外的“幽灵” Action 记录。
- **路径修复**：针对 GoReleaser V2 的路径变动，使用了更健壮的 `find` 命令来定位生成的配方文件。

### 预期效果
合并后，每次发布在 Actions 列表?由于之前尝试中遇到路径报错，我在此重新创建了一个干净的、修复后的版本：

### 1. 核心流程重构
irfarren/peekgit