### PR TITLE
fix: 移除 .goreleaser.yaml 中重复的 skip_upload 键

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -96,4 +96,3 @@ scoops:
       email: bot@goreleaser.com
     commit_msg_template: "chore(release): scoop manifest for {{ .Tag }}"
     skip_upload: true
-    skip_upload: true


### PR DESCRIPTION
## 这次的更改 (Changes Made)

**问题是什么**：
- `.goreleaser.yaml` 文件第 98-99 行存在重复的 `skip_upload: true` 键
- GoReleaser 在解析 YAML 时失败，错误信息：`line 99: mapping key "skip_upload" already defined at line 98`
- 导致 Release workflow 无法正常运行

**解决方案是什么**：
删除第 99 行重复的 `skip_upload: true`

**修复结论是什么**：
YAML 配置文件语法正确，GoReleaser 可以正常解析

## 涉及范围 (Scope of Impact)

- `.goreleaser.yaml` 配置文件
- GitHub Actions Release workflow

## 有没有风险 (Risks)

无明显风险。仅删除重复的配置项，不影响任何功能逻辑。