### PR TITLE
fix(ci): release workflow 使用 App Token 检出代码以便推送

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,17 +63,18 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Generate App Token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
## 这次的更改 (Changes Made)

修复 release workflow 中 `git push origin HEAD:master` 推送失败的问题。

**问题是什么**: 
`release` job 中检出代码时使用了默认的 `GITHUB_TOKEN`，而该 token 无法绕过配置了分支保护规则的 master 分支，导致推送失败。

**解决方案是什么**: 
- 将 "Generate App Token" 步骤调整到 "Checkout" 步骤之前
- 在 Checkout 步骤中添加 `token: ${{ steps.app-token.outputs.token }}`，使用 `peekgit-release-bot` 的 token 检出代码

**修复结论是什么**: 
这样后续的 `git push` 会使用 App 的权限，能够绕过分支保护规则成功推送。

## 涉及范围 (Scope of Impact)

- `.github/workflows/release.yml` 文件
- 仅影响 release workflow 中的推送步骤

## 有没有风险 (Risks)

无明显风险。仅调整了步骤顺序和 token 使用方式，不影响其他 workflow 逻辑。