### PR TITLE
fix(tui): add immediate loading feedback for pull commands

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -386,6 +386,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case pullDoneMsg:
+		a.repoRefreshing[m.repoPath] = false
 		if m.err != nil {
 			a.errText = "pull 失败: " + m.err.Error()
 		} else {
@@ -394,6 +395,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, a.refreshAllCmd()
 
 	case pullAllDoneMsg:
+		for path := range a.repoRefreshing {
+			a.repoRefreshing[path] = false
+		}
 		if m.failed > 0 && m.lastErr != nil {
 			a.errText = fmt.Sprintf("pull 完成: %d 成功, %d 失败 (%s)", m.completed, m.failed, m.lastErr.Error())
 		} else {
@@ -666,10 +670,15 @@ func (a *App) updateHome(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return a, a.loadRemoteCmd(visible[a.selectedIndex])
 	case "f":
 		if len(visible) > 0 {
+			repo := visible[a.selectedIndex]
+			a.repoRefreshing[repo.Path] = true
 			return a, a.pullCurrentCmd()
 		}
 	case "F":
 		if len(a.repos) > 0 {
+			for _, repo := range a.repos {
+				a.repoRefreshing[repo.Path] = true
+			}
 			return a, a.pullAllCmd()
 		}
 	case "g":


### PR DESCRIPTION
## Summary

- 按 `f` 键时立即显示当前选中卡片的 loading 状态（spinner）
- 按 `F` 键时立即显示所有卡片的 loading 状态
- pull 完成后自动清除对应卡片的 loading 状态

## Changes

| 修改点 | 说明 |
|--------|------|
| `f` 按键处理 | 添加 `a.repoRefreshing[repo.Path] = true` |
| `F` 按键处理 | 遍历所有仓库设置 loading 状态 |
| `pullDoneMsg` | 清除对应仓库的 loading 状态 |
| `pullAllDoneMsg` | 清除所有仓库的 loading 状态 |

## Before

- 按 `f`/`F` 后没有立即的视觉反馈
- loading 状态是整个页面而非单个卡片

## After

- 按 `f`/`F` 后对应卡片立即显示 spinner
- loading 状态精确到单个卡片