### PR TITLE
feat(tui): 在 diff 视图中添加逐行滚动快捷键 (ctrl+u/d)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -763,6 +763,10 @@ func (a *App) updateDiff(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Switch to left panel
 		a.diffFocusLeft = true
 		return a, nil
+	case "ctrl+u", "ctrl+d":
+		var cmd tea.Cmd
+		a.diffViewport, cmd = a.diffViewport.Update(msg)
+		return a, cmd
 	}
 
 	// In simple mode, always scroll the diff content
@@ -1433,6 +1437,7 @@ func (a *App) viewDiff() string {
 	help := panelHint + HelpDescStyle.Render("  ") +
 		HelpKeyStyle.Render("↑↓") + HelpDescStyle.Render("选择  ") +
 		HelpKeyStyle.Render("←→") + HelpDescStyle.Render("切换面板  ") +
+		HelpKeyStyle.Render("ctrl+u/d") + HelpDescStyle.Render("滚动右侧  ") +
 		HelpDescStyle.Render("[") + HelpKeyStyle.Render("q") + HelpDescStyle.Render("]退出  ") +
 		cursorStyle.Render("●") + HelpDescStyle.Render(fmt.Sprintf(" %d files", fileCount))
 	lines := []string{"", panels, help}
@@ -1679,7 +1684,7 @@ func formatRelativeTime(t time.Time, now time.Time) string {
 // viewDiffSimple renders a simple single-panel diff view for small screens
 func (a *App) viewDiffSimple() string {
 	header := diffHeaderStyle.Render("Diff")
-	help := HelpKeyStyle.Render("[q]") + HelpDescStyle.Render(" 返回")
+	help := HelpKeyStyle.Render("ctrl+u/d") + HelpDescStyle.Render(" 滚动  ") + HelpKeyStyle.Render("[q]") + HelpDescStyle.Render(" 返回")
 
 	headerLines := []string{header}
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -763,10 +763,12 @@ func (a *App) updateDiff(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Switch to left panel
 		a.diffFocusLeft = true
 		return a, nil
-	case "ctrl+u", "ctrl+d":
-		var cmd tea.Cmd
-		a.diffViewport, cmd = a.diffViewport.Update(msg)
-		return a, cmd
+	case "ctrl+u":
+		a.diffViewport.LineUp(1)
+		return a, nil
+	case "ctrl+d":
+		a.diffViewport.LineDown(1)
+		return a, nil
 	}
 
 	// In simple mode, always scroll the diff content
@@ -1437,7 +1439,7 @@ func (a *App) viewDiff() string {
 	help := panelHint + HelpDescStyle.Render("  ") +
 		HelpKeyStyle.Render("↑↓") + HelpDescStyle.Render("选择  ") +
 		HelpKeyStyle.Render("←→") + HelpDescStyle.Render("切换面板  ") +
-		HelpKeyStyle.Render("ctrl+u/d") + HelpDescStyle.Render("滚动右侧  ") +
+		HelpKeyStyle.Render("ctrl+u/d") + HelpDescStyle.Render("逐行滚动  ") +
 		HelpDescStyle.Render("[") + HelpKeyStyle.Render("q") + HelpDescStyle.Render("]退出  ") +
 		cursorStyle.Render("●") + HelpDescStyle.Render(fmt.Sprintf(" %d files", fileCount))
 	lines := []string{"", panels, help}


### PR DESCRIPTION
## 这次的更改 (Changes Made)
- 在 `internal/tui/app.go` 的 `updateDiff` 函数中，将 `ctrl+u` 和 `ctrl+d` 改为显式调用 `LineUp(1)` 和 `LineDown(1)`。
- 现在在 Diff 视图中，无论焦点在左侧文件列表还是右侧内容区域，都可以通过这两个快捷键实现 **1行1行** 的精细滚动。
- 更新了分栏视图和简单视图下的帮助提示信息，增加了“逐行滚动”说明。

## 涉及范围 (Scope of Impact)
- PR 详情中的 Diff 查看界面。

## 有没有风险 (Risks)
- 无风险。